### PR TITLE
fix(windows): 修复 64 核 Windows 物理机 CPU 使用率负数问题

### DIFF
--- a/metric/cpu/metrics.go
+++ b/metric/cpu/metrics.go
@@ -33,14 +33,15 @@ import (
 // should assume that any value can be null.
 // The values are in "ticks", which translates to milliseconds of CPU time
 type CPU struct {
-	User    opt.Uint `struct:"user,omitempty"`
-	Sys     opt.Uint `struct:"system,omitempty"`
-	Idle    opt.Uint `struct:"idle,omitempty"`
-	Nice    opt.Uint `struct:"nice,omitempty"`    // Linux, Darwin, BSD
-	Irq     opt.Uint `struct:"irq,omitempty"`     // Linux and openbsd
-	Wait    opt.Uint `struct:"iowait,omitempty"`  // Linux and AIX
-	SoftIrq opt.Uint `struct:"softirq,omitempty"` // Linux only
-	Stolen  opt.Uint `struct:"steal,omitempty"`   // Linux only
+	User       opt.Uint `struct:"user,omitempty"`
+	Sys        opt.Uint `struct:"system,omitempty"`
+	Idle       opt.Uint `struct:"idle,omitempty"`
+	Nice       opt.Uint `struct:"nice,omitempty"`    // Linux, Darwin, BSD
+	Irq        opt.Uint `struct:"irq,omitempty"`     // Linux and openbsd
+	Wait       opt.Uint `struct:"iowait,omitempty"`  // Linux and AIX
+	SoftIrq    opt.Uint `struct:"softirq,omitempty"` // Linux only
+	Stolen     opt.Uint `struct:"steal,omitempty"`   // Linux only
+	TotalTicks opt.Uint `struct:"total,omitempty"`   // Pre-computed total, used on Windows where uint64 overflow can occur
 }
 
 // MetricOpts defines the fields that are passed along to the formatted output
@@ -72,10 +73,14 @@ type CPUMetrics struct {
 	CPUInfo []CPUInfo
 }
 
-// Total returns the total CPU time in ticks as scraped by the API
+// Total returns the total CPU time in ticks as scraped by the API.
+// If a pre-computed TotalTicks value is available (e.g. from Windows where
+// uint64 overflow can occur), it is used. Otherwise, the total is
+// computed as the sum of all CPU state fields.
 func (cpu CPU) Total() uint64 {
-	// it's generally safe to blindly sum these up,
-	// As we're just trying to get a total of all CPU time.
+	if !cpu.TotalTicks.IsZero() {
+		return cpu.TotalTicks.ValueOr(0)
+	}
 	return opt.SumOptUint(cpu.User, cpu.Nice, cpu.Sys, cpu.Idle, cpu.Wait, cpu.Irq, cpu.SoftIrq, cpu.Stolen)
 }
 
@@ -181,7 +186,22 @@ func (metric Metrics) Format(opts MetricOpts) (mapstr.M, error) {
 
 	// /proc/stat metrics
 	reportOptMetric("user", metric.currentSample.User, metric.previousSample.User, normCPU)
-	reportOptMetric("system", metric.currentSample.Sys, metric.previousSample.Sys, normCPU)
+	if !metric.currentSample.Sys.IsZero() || !metric.previousSample.Sys.IsZero() {
+		reportOptMetric("system", metric.currentSample.Sys, metric.previousSample.Sys, normCPU)
+	} else {
+		// Windows path: Sys was not set due to kernel < idle (uint64 overflow).
+		// Derive systemPct = totalPct - userPct via dot-path Put for proper merging.
+		if opts.NormalizedPercentages {
+			totalPct := createTotal(metric.previousSample, metric.currentSample, timeDelta, 1)
+			userPct := cpuMetricTimeDelta(metric.previousSample.User, metric.currentSample.User, timeDelta, 1)
+			_, _ = formattedMetrics.Put("system.norm.pct", totalPct-userPct)
+		}
+		if opts.Percentages {
+			totalPct := createTotal(metric.previousSample, metric.currentSample, timeDelta, normCPU)
+			userPct := cpuMetricTimeDelta(metric.previousSample.User, metric.currentSample.User, timeDelta, normCPU)
+			_, _ = formattedMetrics.Put("system.pct", totalPct-userPct)
+		}
+	}
 	reportOptMetric("idle", metric.currentSample.Idle, metric.previousSample.Idle, normCPU)
 	reportOptMetric("nice", metric.currentSample.Nice, metric.previousSample.Nice, normCPU)
 	reportOptMetric("irq", metric.currentSample.Irq, metric.previousSample.Irq, normCPU)

--- a/metric/cpu/metrics_test.go
+++ b/metric/cpu/metrics_test.go
@@ -159,3 +159,71 @@ func TestMetricsPercentages(t *testing.T) {
 	assert.EqualValues(t, .0, idle.(float64))
 	assert.EqualValues(t, 1., total.(float64))
 }
+
+// TestTotalTicksPreferred tests that Total() returns the pre-computed
+// TotalTicks value when set, rather than summing the individual fields.
+func TestTotalTicksPreferred(t *testing.T) {
+	cpu := CPU{
+		User:       opt.UintWith(100),
+		Sys:        opt.UintWith(0),
+		Idle:       opt.UintWith(9000),
+		TotalTicks: opt.UintWith(10000),
+	}
+	assert.Equal(t, uint64(10000), cpu.Total())
+
+	// Without TotalTicks, Total falls back to summing fields
+	cpu2 := CPU{
+		User:       opt.UintWith(100),
+		Sys:        opt.UintWith(0),
+		Idle:       opt.UintWith(9000),
+	}
+	assert.Equal(t, uint64(9100), cpu2.Total())
+}
+
+// TestWindowsNegativeKernelDerivation tests that when Sys is zero-value
+// (Windows kernel < idle overflow, so Sys was left as opt.Uint{}),
+// system pct is derived as totalPct - userPct, and all percentages are valid.
+func TestWindowsNegativeKernelDerivation(t *testing.T) {
+	// Layout: idle=70%, user=20%, system=10% of total.
+	// Sys is not set (IsZero()=true) to simulate Windows overflow path.
+	// TotalTicks carries the correct total computed via int64.
+	prev := CPU{
+		User:       opt.UintWith(20000),
+		Idle:       opt.UintWith(70000),
+		Sys:        opt.Uint{}, // overflowed, not set
+		TotalTicks: opt.UintWith(100000),
+	}
+	cur := CPU{
+		User:       opt.UintWith(22000),  // +2000
+		Idle:       opt.UintWith(77000),  // +7000
+		Sys:        opt.Uint{},           // still overflowed
+		TotalTicks: opt.UintWith(110000), // +10000
+	}
+
+	sample := Metrics{
+		count:          64,
+		isTotals:       true,
+		previousSample: prev,
+		currentSample:  cur,
+	}
+
+	evt, err := sample.Format(MetricOpts{NormalizedPercentages: true, Percentages: true})
+	assert.NoError(t, err)
+
+	// total.norm.pct = 1 - idlePct = 1 - 0.7 = 0.30
+	totalNormPct, _ := evt.GetValue("total.norm.pct")
+	assert.InDelta(t, 0.30, totalNormPct.(float64), 0.01)
+
+	// user.norm.pct = 2000/10000 = 0.20
+	userNormPct, _ := evt.GetValue("user.norm.pct")
+	assert.InDelta(t, 0.20, userNormPct.(float64), 0.01)
+
+	// system.norm.pct = totalPct - userPct = 0.30 - 0.20 = 0.10
+	sysNormPct, _ := evt.GetValue("system.norm.pct")
+	assert.InDelta(t, 0.10, sysNormPct.(float64), 0.01)
+
+	// idle + user + system ≈ 1.0 (normalized)
+	idleNormPct, _ := evt.GetValue("idle.norm.pct")
+	sum := idleNormPct.(float64) + userNormPct.(float64) + sysNormPct.(float64)
+	assert.InDelta(t, 1.0, sum, 0.01, "idle+user+system should sum to ~1.0 (normalized)")
+}

--- a/metric/cpu/metrics_windows.go
+++ b/metric/cpu/metrics_windows.go
@@ -39,13 +39,26 @@ func Get(_ resolve.Resolver) (CPUMetrics, error) {
 	}
 
 	globalMetrics := CPUMetrics{}
-	//convert from duration to ticks
+
+	// Use int64 intermediate variables to avoid uint64 overflow when
+	// gosigar returns negative kernel (happens when rawIdle > rawKernel
+	// on some 64-core Windows machines).
+	totalMs := int64(idle/time.Millisecond) + int64(kernel/time.Millisecond) + int64(user/time.Millisecond)
+	if totalMs < 0 {
+		totalMs = 0
+	}
+
+	// convert from duration to ticks
 	idleMetric := uint64(idle / time.Millisecond)
-	sysMetric := uint64(kernel / time.Millisecond)
+	sysMetric := opt.Uint{}
+	if kernel >= 0 {
+		sysMetric = opt.UintWith(uint64(kernel / time.Millisecond))
+	}
 	userMetrics := uint64(user / time.Millisecond)
 	globalMetrics.totals.Idle = opt.UintWith(idleMetric)
-	globalMetrics.totals.Sys = opt.UintWith(sysMetric)
+	globalMetrics.totals.Sys = sysMetric
 	globalMetrics.totals.User = opt.UintWith(userMetrics)
+	globalMetrics.totals.TotalTicks = opt.UintWith(uint64(totalMs))
 
 	// get per-cpu data
 	cpus, err := windows.NtQuerySystemProcessorPerformanceInformation()
@@ -54,13 +67,23 @@ func Get(_ resolve.Resolver) (CPUMetrics, error) {
 	}
 	globalMetrics.list = make([]CPU, 0, len(cpus))
 	for _, cpu := range cpus {
-		idleMetric := uint64(cpu.IdleTime / time.Millisecond)
-		sysMetric := uint64(cpu.KernelTime / time.Millisecond)
-		userMetrics := uint64(cpu.UserTime / time.Millisecond)
+		perIdleMs := int64(cpu.IdleTime / time.Millisecond)
+		perKernelMs := int64(cpu.KernelTime / time.Millisecond)
+		perUserMs := int64(cpu.UserTime / time.Millisecond)
+		perTotalMs := perIdleMs + perKernelMs + perUserMs
+		if perTotalMs < 0 {
+			perTotalMs = 0
+		}
+		perSysMs := opt.Uint{}
+		if perKernelMs >= 0 {
+			perSysMs = opt.UintWith(uint64(perKernelMs))
+		}
+
 		globalMetrics.list = append(globalMetrics.list, CPU{
-			Idle: opt.UintWith(idleMetric),
-			Sys:  opt.UintWith(sysMetric),
-			User: opt.UintWith(userMetrics),
+			Idle:       opt.UintWith(uint64(perIdleMs)),
+			Sys:        perSysMs,
+			User:       opt.UintWith(uint64(perUserMs)),
+			TotalTicks: opt.UintWith(uint64(perTotalMs)),
 		})
 	}
 


### PR DESCRIPTION
部分 64 逻辑 CPU 的 Windows 物理机上，GetSystemTimes() API 返回 idle > kernel（违反 kernel 包含 idle 的文档约定），gosigar 执行
kernel - idle 得到负数，uint64 转换溢出回绕为极大值，导致 Total()
和所有百分比计算全部错乱。

修复方案：
- metrics_windows.go: 用 int64 中间变量计算 Total，避免 uint64 溢出； kernel 为负时将 Sys 设为 opt.Uint 零值（IsZero()=true）
- metrics.go: CPU struct 新增 TotalTicks 字段，Total() 优先使用预计算值； Format() 中当 Sys 未设置时通过 totalPct - userPct 派生 system 百分比
- metrics_test.go: 新增 TotalTicks 优先级测试和 Windows 负数场景派生测试

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

